### PR TITLE
Make changes necessary for editor transform-scale

### DIFF
--- a/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.cpp
@@ -9,11 +9,17 @@ static DualMap<std::string, BodyTypeEnum> BodyTypeEnumStringMap {
         { "environment", BodyType::Environment }
 };
 
-CollisionComponent::CollisionComponent(CollisionSystem * collisionSystem,
-        const sf::Vector3f & dim,
+CollisionComponent::CollisionComponent(
+        CollisionSystem * collisionSystem,
+        const Box2 & dim,
+        const sf::Vector2f & scale,
         CollisionType type,
-        BodyTypeEnum bodyType)
-    : _system(collisionSystem), _dim(dim.x,dim.y), _type(type), _bodyType(bodyType)
+        BodyTypeEnum bodyType) :
+    _system(collisionSystem),
+    _dim(dim),
+    _scale(scale),
+    _type(type),
+    _bodyType(bodyType)
 {
 
 }
@@ -69,6 +75,7 @@ struct Serializer<BodyTypeEnum> {
 
 void CollisionComponent::Serialize(Archive &arc) {
     arc(_dim, "dimension");
+    arc(_scale, "scale");
     arc(_bodyType, "bodyType");
     arc.system(_system, "collision");
 

--- a/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.cpp
@@ -26,7 +26,7 @@ CollisionComponent::CollisionComponent(
 
 bool CollisionComponent::Collides(const CollisionComponent & otherComponent, Point & fixNormal, float & fixMagnitude)
 {
-    return _dim.Intersects(otherComponent._dim, fixNormal, fixMagnitude);
+    return box().Intersects(otherComponent.box(), fixNormal, fixMagnitude);
 }
 
 void CollisionComponent::Update()
@@ -95,4 +95,13 @@ void CollisionComponent::Serialize(Archive &arc) {
 
 void CollisionComponent::FetchDependencies(const Entity &entity) {
     _position = _system->position()[entity];
+}
+
+
+const Box2 CollisionComponent::box() const
+{
+    auto box = Box2(_dim.Position, _dim.Dimension, _dim.Rotation);
+    box.Dimension.x * _scale.x;
+    box.Dimension.y * _scale.y;
+    return box;
 }

--- a/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.hpp
@@ -98,7 +98,7 @@ class CollisionComponent
         BodyTypeEnum bodyType() { return _bodyType; }
         void bodyType(BodyTypeEnum bodyType) { _bodyType = bodyType; }
         PositionComponent & positionComponent() { return *_position; }
-        const Box2 & box() const { return _dim; }
+        const Box2 box() const;
         const sf::Vector2f & scale() const { return _scale; }
         void scale(const sf::Vector2f & scale) { _scale = scale; }
 

--- a/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.hpp
@@ -50,11 +50,16 @@ class CollisionComponent
          * @brief Construct a collision component.
          *
          * @param collisionSystem The system describing the entities position.
-         * @param dim A vector describing the entities dimmension.
+         * @param dim A box describing the entities dimmension.
          * @param type Type of entity for collisions.
          * @param bodyType BodyType of the collision component.  Determines how collision fixing is performed.
          */
-        CollisionComponent(CollisionSystem * collisionSystem, const sf::Vector3f & dim, CollisionType type, BodyTypeEnum bodyType);
+        CollisionComponent(
+            CollisionSystem * collisionSystem,
+            const Box2 & dim,
+            const sf::Vector2f & scale,
+            CollisionType type,
+            BodyTypeEnum bodyType);
 
         /*
          * Constructor that should only be used by the loading system.
@@ -94,11 +99,14 @@ class CollisionComponent
         void bodyType(BodyTypeEnum bodyType) { _bodyType = bodyType; }
         PositionComponent & positionComponent() { return *_position; }
         const Box2 & box() const { return _dim; }
+        const sf::Vector2f & scale() const { return _scale; }
+        void scale(const sf::Vector2f & scale) { _scale = scale; }
 
     private:
         PositionComponent * _position;
         CollisionSystem * _system;
         Box2 _dim;
+        sf::Vector2f _scale;
         CollisionType _type;
         BodyTypeEnum _bodyType;
 };

--- a/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionSystem.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionSystem.cpp
@@ -131,13 +131,15 @@ void CollisionSystem::Update(float delta)
 
 }
 
-CollisionComponent * CollisionSystem::CreateComponent(const Entity & entity,
-        const sf::Vector3f & dim,
-        CollisionType type,
-        BodyTypeEnum bodyType)
+CollisionComponent * CollisionSystem::CreateComponent(
+    const Entity & entity,
+    const Box2 & dim,
+    const sf::Vector2f & scale,
+    CollisionType type,
+    BodyTypeEnum bodyType)
 {
     Assert(type < _nextType, "Cannot use a collision type that is undefined");
-    auto component = new CollisionComponent(this, dim, type, bodyType);
+    auto component = new CollisionComponent(this, dim, scale, type, bodyType);
 
     AttachComponent(entity, component);
 

--- a/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionSystem.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionSystem.hpp
@@ -46,16 +46,19 @@ class CollisionSystem : public UnorderedSystem<CollisionComponent>
          *
          * @param entity Entity that the component is attached to.
          * @param dim Dimension for the entity to be used for collision.
+         * @param scale Scale of the collision component.
          * @param type The collision type of the entity.
          * @param bodyType The body type of the entity.  Determines how collision fixing
          *  is handled for it. Defaults to BodyType::None.
          *
          * @return A pointer to the component.
          */
-        CollisionComponent * CreateComponent(const Entity & entity,
-                const sf::Vector3f & dim,
-                CollisionType type,
-                BodyTypeEnum bodyType = BodyType::None);
+        CollisionComponent * CreateComponent(
+            const Entity & entity,
+            const Box2 & dim,
+            const sf::Vector2f & scale,
+            CollisionType type,
+            BodyTypeEnum bodyType = BodyType::None);
 
         /**
          * @brief Create a Type that can be assigned to a component.

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.cpp
@@ -37,7 +37,7 @@ void Drawable::Draw(sf::RenderWindow &window, sf::Transform parentTransform, flo
 sf::Transform Drawable::CalculateTransforms()
 {
     sf::Transform transform;
-    transform.translate(_positionOffset).rotate(_rotation).scale(_scale);
+    transform.translate(_positionOffset).scale(_scale).rotate(_rotation);
     return transform;
 }
 
@@ -53,4 +53,3 @@ Drawable * Drawable::FindDrawable(const std::string &key)
     }
     return nullptr;
 }
-

--- a/Engine/Src/Ancona/Extensions/SFML/OvalShape.hpp
+++ b/Engine/Src/Ancona/Extensions/SFML/OvalShape.hpp
@@ -1,0 +1,49 @@
+#ifndef Ancona_Engine_Extensions_SFML_OvalShape_H_
+#define Ancona_Engine_Extensions_SFML_OvalShape_H_
+
+#include <SFML/Graphics.hpp>
+
+namespace sf
+{
+
+class OvalShape : public sf::Shape
+{
+    public:
+
+        explicit OvalShape(const float radiusWidth = 0, const float radiusHeight = 0) :
+            _radiusWidth(radiusWidth),
+            _radiusHeight(radiusHeight)
+        {
+            update();
+        }
+
+        virtual unsigned int getPointCount() const
+        {
+            return 30;
+        }
+
+        virtual sf::Vector2f getPoint(unsigned int index) const
+        {
+            static const float pi = 3.141592654f;
+
+            float angle = index * 2 * pi / getPointCount() - pi / 2;
+            float x = std::cos(angle) * _radiusWidth;
+            float y = std::sin(angle) * _radiusHeight;
+
+            return sf::Vector2f(_radiusWidth + x, _radiusHeight + y);
+        }
+
+        /* getters and setters */
+        void setRadiusWidth(const float radiusWidth) { _radiusWidth = radiusWidth; update(); }
+        void setRadiusHeight(const float radiusHeight) { _radiusHeight = radiusHeight; update(); }
+        const float getRadiusWidth() const { return _radiusWidth; }
+        const float getRadiusHeight() const { return _radiusHeight; }
+    private:
+        float _radiusWidth;
+        float _radiusHeight;
+
+};
+
+}
+
+#endif

--- a/Engine/Src/Ancona/Extensions/SFML/OvalShape.hpp
+++ b/Engine/Src/Ancona/Extensions/SFML/OvalShape.hpp
@@ -17,12 +17,12 @@ class OvalShape : public sf::Shape
             update();
         }
 
-        virtual unsigned int getPointCount() const
+        virtual std::size_t getPointCount() const
         {
             return 30;
         }
 
-        virtual sf::Vector2f getPoint(unsigned int index) const
+        virtual sf::Vector2f getPoint(std::size_t index) const
         {
             static const float pi = 3.141592654f;
 

--- a/Engine/Src/Ancona/Framework/Serializing/SFMLSerializer.cpp
+++ b/Engine/Src/Ancona/Framework/Serializing/SFMLSerializer.cpp
@@ -24,19 +24,23 @@ void Serializer<sf::RectangleShape>::Serialize(sf::RectangleShape & shape, Archi
     }
 }
 
-void Serializer<sf::CircleShape>::Serialize(sf::CircleShape & shape, Archive & arc){
-    float radius;
+void Serializer<sf::OvalShape>::Serialize(sf::OvalShape & shape, Archive & arc){
+    float radiusWidth;
+    float radiusHeight;
     sf::Color color;
     if (!arc.loading()) {
-        radius = shape.getRadius();
+        radiusWidth = shape.getRadiusWidth();
+        radiusHeight = shape.getRadiusHeight();
         color = shape.getFillColor();
     }
-    arc(radius, "radius");
+    arc(radiusWidth, "radiusWidth");
+    arc(radiusHeight, "radiusHeight");
     arc(color, "fillColor");
 
     if (arc.loading())
     {
-        shape.setRadius(radius);
+        shape.setRadiusWidth(radiusWidth);
+        shape.setRadiusHeight(radiusHeight);
         shape.setFillColor(color);
     }
 }

--- a/Engine/Src/Ancona/Framework/Serializing/SFMLSerializer.hpp
+++ b/Engine/Src/Ancona/Framework/Serializing/SFMLSerializer.hpp
@@ -3,6 +3,7 @@
 
 #include <SFML/System.hpp>
 
+#include <Ancona/Extensions/SFML/OvalShape.hpp>
 #include <Ancona/Framework/Serializing/Archive.hpp>
 #include <Ancona/Framework/Serializing/Serializer.hpp>
 #include <Ancona/Framework/Serializing/StdSerializer.hpp>
@@ -99,9 +100,9 @@ struct Serializer<sf::RectangleShape>
 };
 
 template <>
-struct Serializer<sf::CircleShape>
+struct Serializer<sf::OvalShape>
 {
-    static void Serialize(sf::CircleShape & shape, Archive & arc);
+    static void Serialize(sf::OvalShape & shape, Archive & arc);
 };
 
 template <>

--- a/Engine/Src/Ancona/Framework/Serializing/SFMLSerializer.hpp
+++ b/Engine/Src/Ancona/Framework/Serializing/SFMLSerializer.hpp
@@ -61,10 +61,12 @@ struct Serializer<sf::Text>
         {
             arc(fontKey, "fontKey");
             property.setString(text);
-            property.setFont(*ResourceLibrary::Get<sf::Font>(fontKey));
+            if (fontKey != "") {
+                property.setFont(*ResourceLibrary::Get<sf::Font>(fontKey));
+            }
             property.setFillColor(color);
             property.setCharacterSize(characterSize);
-            if (!smooth)
+            if (!smooth && fontKey != "")
             {
                 const_cast<sf::Texture&>(property.getFont()->getTexture(characterSize)).setSmooth(false);
             }


### PR DESCRIPTION
Should be reviewed and pulled with: https://github.com/JeffSwenson/duckling/pull/178

* Adds scale to collision component
* Implements sf::OvalShape and serialize it
* Apply rotation before scale