### PR TITLE
update the collision box position during FetchDependencies

### DIFF
--- a/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.cpp
@@ -106,4 +106,5 @@ void CollisionComponent::Serialize(Archive &arc) {
 
 void CollisionComponent::FetchDependencies(const Entity &entity) {
     _position = _system->position()[entity];
+    UpdateDimensionPosition();
 }


### PR DESCRIPTION
Resolves #102 
 **Commit message:**
Call CollisionComponent::UpdateDimensionPosition during CollisionComponent::FetchDependencies

`https://github.com/ild-games/Ancona/issues/102`

Collision boxes have a position that is updated every frame during the update loop for the CollisionSystem. But the boxes aren't updated during entity creation so its possible to call CollisionSystem::GetCollisions before collision boxes have been moved from 0,0 to the correct location. This pull request calls UpdateDimensionPosition during FetchDependencies so that the box position will be correct during component initialization. 