### PR TITLE
implement tile block drawables

### DIFF
--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.hpp
@@ -96,7 +96,7 @@ class AnimatedDrawable : public Drawable
         std::vector<std::unique_ptr<Drawable>> _frames;
         float _duration;
         float _timeUntilChange;
-        int _curFrame = 0;
+        uint _curFrame = 0;
         bool _loopOnce = false;
 
 

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.cpp
@@ -10,10 +10,10 @@ Drawable::Drawable(
         const std::string & key,
         int priorityOffset,
         sf::Vector2f anchor) :
+    _key(key),
     _anchor(anchor),
     _renderPriority(priority),
-    _priorityOffset(priorityOffset),
-    _key(key)
+    _priorityOffset(priorityOffset)
 {
 
 }

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/ImageDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/ImageDrawable.cpp
@@ -8,40 +8,18 @@ using namespace ild;
 ImageDrawable::ImageDrawable(
         std::string textureKey,
         const int priority,
-        const std::string & key,
-        bool isWholeImage,
-        Box2 textureRect,
-        int priorityOffset,
-        sf::Vector2f anchor) :
-    Drawable(
-            priority,
-            key,
-            priorityOffset,
-            anchor),
-    _textureKey(textureKey),
-    _textureRect(textureRect),
-    _isWholeImage(isWholeImage)
+        const std::string & key) :
+    Drawable(priority, key),
+    _textureKey(textureKey)
 {
 }
 
 ImageDrawable::ImageDrawable(
-        sf::Texture * texture,
         const int priority,
-        const std::string & key,
-        bool isWholeImage,
-        Box2 textureRect,
-        int priorityOffset,
-        sf::Vector2f anchor) :
-    Drawable(
-            priority,
-            key,
-            priorityOffset,
-            anchor),
-    _textureKey(""),
-    _textureRect(textureRect),
-    _isWholeImage(isWholeImage)
+        const std::string & key) :
+    Drawable(priority, key),
+    _textureKey("")
 {
-    SetupSprite(texture);
 }
 
 void ImageDrawable::OnDraw(sf::RenderWindow &window, sf::Transform drawableTransform, float delta)

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/ImageDrawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/ImageDrawable.hpp
@@ -8,70 +8,42 @@
 namespace ild
 {
 
-/**
- * @brief A drawable which can display either a whole image or a portion of an image.
- *
- * @author Tucker Lein
- */
 class ImageDrawable : public Drawable
 {
     public:
-        /**
-         * @brief Blank constructor needed for serializing.
-         */
         ImageDrawable() { }
 
-        /**
-         * @brief Constructs an ImageDrawable
-         */
         ImageDrawable(
                 std::string textureKey,
                 const int priority,
-                const std::string & key,
-                bool isWholeImage = true,
-                Box2 textureRect = Box2(sf::Vector2f(0, 0), sf::Vector2f(0, 0)),
-                int priorityOffset = 0,
-                sf::Vector2f anchor = sf::Vector2f(0, 0));
+                const std::string & key);
 
-        /**
-         * @brief Constructs an ImageDrawable
-         *
-         * @param texture Texture to use for the image.
-         * @param textureRect IntRect that describes the rectangle of the texture to display.
-         */
         ImageDrawable(
-                sf::Texture * texture,
                 const int priority,
-                const std::string & key,
-                bool isWholeImage = true,
-                Box2 textureRect = Box2(sf::Vector2f(0, 0), sf::Vector2f(0, 0)),
-                int priorityOffset = 0,
-                sf::Vector2f anchor = sf::Vector2f(0, 0));
+                const std::string & key);
 
-        /**
-         * @copydoc ild::CameraComponent::Serialize
-         */
         void Serialize(Archive & arc) override;
 
-        /**
-         * @copydoc ild::CameraComponent::FetchDependencies
-         */
         void FetchDependencies(const Entity & entity) override;
+
+        void SetupSprite(sf::Texture * texture);
 
         /* getters and setters */
         sf::Vector2f size() override;
         void alpha(int newAlpha) override;
         int alpha() override;
+        void isWholeImage(bool isWholeImage) { _isWholeImage = isWholeImage; }
+        void isTiled(bool isTiled) { _isTiled = isTiled; }
+        void tiledArea(const sf::Vector2f & tiledArea) { _tiledArea = tiledArea; }
     private:
         std::string _textureKey;
         Box2 _textureRect;
         std::unique_ptr<sf::Sprite> _sprite;
         sf::Vector2f _tiledArea;
         bool _isTiled = false;
-        bool _isWholeImage = false;
+        bool _isWholeImage = true;
 
         void OnDraw(sf::RenderWindow &window, sf::Transform transform, float delta) override;
-        void SetupSprite(sf::Texture * texture);
 };
 
 }

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.cpp
@@ -33,15 +33,41 @@ void TileBlockDrawable::SetupImages(sf::Image image) {
         _imageDrawables.emplace_back(bottomLeftDrawable(image));
         _imageDrawables.emplace_back(bottomRightDrawable(image));
     }
-    if (_numTiles.y > 1) {
+
+    if (_numTiles.x > 2 && _numTiles.y > 1) {
         _imageDrawables.emplace_back(topDrawable(image));
         _imageDrawables.emplace_back(bottomDrawable(image));
     }
-    if (_numTiles.x > 1) {
+    if (_numTiles.y > 2 && _numTiles.x > 1) {
         _imageDrawables.emplace_back(leftDrawable(image));
         _imageDrawables.emplace_back(rightDrawable(image));
     }
-    _imageDrawables.emplace_back(centerDrawable(image));
+
+    if (_numTiles.x > 2 && _numTiles.y > 2) {
+        _imageDrawables.emplace_back(centerDrawable(image));
+    }
+
+    if (_numTiles.y > 1 && _numTiles.x == 1) {
+        _imageDrawables.emplace_back(topCapDrawable(image));
+        _imageDrawables.emplace_back(bottomCapDrawable(image));
+    }
+
+    if (_numTiles.x > 1 && _numTiles.y == 1) {
+        _imageDrawables.emplace_back(leftCapDrawable(image));
+        _imageDrawables.emplace_back(rightCapDrawable(image));
+    }
+
+    if (_numTiles.y > 2 && _numTiles.x == 1) {
+        _imageDrawables.emplace_back(verticalCenterDrawable(image));
+    }
+
+    if (_numTiles.x > 2 && _numTiles.y == 1) {
+        _imageDrawables.emplace_back(horizontalCenterDrawable(image));
+    }
+
+    if (_numTiles.y == 1 && _numTiles.x == 1) {
+        _imageDrawables.emplace_back(singleDrawable(image));
+    }
 }
 
 ImageDrawable * TileBlockDrawable::topLeftDrawable(sf::Image image) {
@@ -80,128 +106,132 @@ ImageDrawable * TileBlockDrawable::bottomRightDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::topDrawable(sf::Image image) {
-    if (_numTiles.x > 1) {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(_tileSize.x, 0, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_top");
-        auto width = _tileSize.x * (_numTiles.x - 2);
-        drawable->anchor(sf::Vector2f(-(_tileSize.x / width), 0));
-        drawable->isTiled(true);
-        drawable->tiledArea(sf::Vector2f(width, _tileSize.y));
-        drawable->SetupSprite(texture);
-        return drawable;
-    } else {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, 0, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_top");
-        drawable->SetupSprite(texture);
-        return drawable;
-    }
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x, 0, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_top");
+    auto width = _tileSize.x * (_numTiles.x - 2);
+    drawable->anchor(sf::Vector2f(-(_tileSize.x / width), 0));
+    drawable->isTiled(true);
+    drawable->tiledArea(sf::Vector2f(width, _tileSize.y));
+    drawable->SetupSprite(texture);
+    return drawable;
 }
 
 ImageDrawable * TileBlockDrawable::bottomDrawable(sf::Image image) {
-    if (_numTiles.x > 1) {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y * 2, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_bottom");
-        auto width = _tileSize.x * (_numTiles.x - 2);
-        drawable->anchor(sf::Vector2f(-(_tileSize.x / width), -(_numTiles.y - 1)));
-        drawable->isTiled(true);
-        drawable->tiledArea(sf::Vector2f(width, _tileSize.y));
-        drawable->SetupSprite(texture);
-        return drawable;
-    } else {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y * 2, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_bottom");
-        drawable->anchor(sf::Vector2f(0, -(_numTiles.y - 1)));
-        drawable->SetupSprite(texture);
-        return drawable;
-    }
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y * 2, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_bottom");
+    auto width = _tileSize.x * (_numTiles.x - 2);
+    drawable->anchor(sf::Vector2f(-(_tileSize.x / width), -(_numTiles.y - 1)));
+    drawable->isTiled(true);
+    drawable->tiledArea(sf::Vector2f(width, _tileSize.y));
+    drawable->SetupSprite(texture);
+    return drawable;
 }
 
 ImageDrawable * TileBlockDrawable::leftDrawable(sf::Image image) {
-    if (_numTiles.y > 1) {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(0, _tileSize.y, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_left");
-        auto height = _tileSize.y * (_numTiles.y - 2);
-        drawable->anchor(sf::Vector2f(0, -(_tileSize.y / height)));
-        drawable->isTiled(true);
-        drawable->tiledArea(sf::Vector2f(_tileSize.x, height));
-        drawable->SetupSprite(texture);
-        return drawable;
-    } else {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(0, _tileSize.y * 3, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_left");
-        drawable->SetupSprite(texture);
-        return drawable;
-    }
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(0, _tileSize.y, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_left");
+    auto height = _tileSize.y * (_numTiles.y - 2);
+    drawable->anchor(sf::Vector2f(0, -(_tileSize.y / height)));
+    drawable->isTiled(true);
+    drawable->tiledArea(sf::Vector2f(_tileSize.x, height));
+    drawable->SetupSprite(texture);
+    return drawable;
 }
 
 ImageDrawable * TileBlockDrawable::rightDrawable(sf::Image image) {
-    if (_numTiles.y > 1) {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, _tileSize.y, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_right");
-        auto height = _tileSize.y * (_numTiles.y - 2);
-        drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), -(_tileSize.y / height)));
-        drawable->isTiled(true);
-        drawable->tiledArea(sf::Vector2f(_tileSize.x, height));
-        drawable->SetupSprite(texture);
-        return drawable;
-    } else {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, _tileSize.y * 3, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_right");
-        drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), 0));
-        drawable->SetupSprite(texture);
-        return drawable;
-    }
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, _tileSize.y, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_right");
+    auto height = _tileSize.y * (_numTiles.y - 2);
+    drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), -(_tileSize.y / height)));
+    drawable->isTiled(true);
+    drawable->tiledArea(sf::Vector2f(_tileSize.x, height));
+    drawable->SetupSprite(texture);
+    return drawable;
 }
 
 ImageDrawable * TileBlockDrawable::centerDrawable(sf::Image image) {
-    if (_numTiles.x > 1 && _numTiles.y > 1) {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
-        auto width = _tileSize.x * (_numTiles.x - 2);
-        auto height = _tileSize.y * (_numTiles.y - 2);
-        drawable->anchor(sf::Vector2f(-(_tileSize.x / width), -(_tileSize.y / height)));
-        drawable->isTiled(true);
-        drawable->tiledArea(sf::Vector2f(width, height));
-        drawable->SetupSprite(texture);
-        return drawable;
-    } else if (_numTiles.x == 1 && _numTiles.y > 1) {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
-        auto width = _tileSize.x * (_numTiles.x - 2);
-        auto height = _tileSize.y * (_numTiles.y - 2);
-        drawable->anchor(sf::Vector2f(0, -(_tileSize.y / height)));
-        drawable->isTiled(true);
-        drawable->tiledArea(sf::Vector2f(_tileSize.x, height));
-        drawable->SetupSprite(texture);
-        return drawable;
-    } else if (_numTiles.x > 1 && _numTiles.y == 1) {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y * 3, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
-        auto width = _tileSize.x * (_numTiles.x - 2);
-        auto height = _tileSize.y * (_numTiles.y - 2);
-        drawable->anchor(sf::Vector2f(-(_tileSize.x / width), 0));
-        drawable->isTiled(true);
-        drawable->tiledArea(sf::Vector2f(width, _tileSize.y));
-        drawable->SetupSprite(texture);
-        return drawable;
-    } else {
-        sf::Texture * texture = new sf::Texture();
-        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y * 3, _tileSize.x, _tileSize.y));
-        auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
-        drawable->SetupSprite(texture);
-        return drawable;
-    }
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
+    auto width = _tileSize.x * (_numTiles.x - 2);
+    auto height = _tileSize.y * (_numTiles.y - 2);
+    drawable->anchor(sf::Vector2f(-(_tileSize.x / width), -(_tileSize.y / height)));
+    drawable->isTiled(true);
+    drawable->tiledArea(sf::Vector2f(width, height));
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::topCapDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, 0, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_topCap");
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::bottomCapDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y * 2, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_bottomCap");
+    drawable->anchor(sf::Vector2f(0, -(_numTiles.y - 1)));
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::leftCapDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(0, _tileSize.y * 3, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_leftCap");
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::rightCapDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, _tileSize.y * 3, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_right");
+    drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), 0));
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::verticalCenterDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
+    auto width = _tileSize.x * (_numTiles.x - 2);
+    auto height = _tileSize.y * (_numTiles.y - 2);
+    drawable->anchor(sf::Vector2f(0, -(_tileSize.y / height)));
+    drawable->isTiled(true);
+    drawable->tiledArea(sf::Vector2f(_tileSize.x, height));
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::horizontalCenterDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y * 3, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
+    auto width = _tileSize.x * (_numTiles.x - 2);
+    auto height = _tileSize.y * (_numTiles.y - 2);
+    drawable->anchor(sf::Vector2f(-(_tileSize.x / width), 0));
+    drawable->isTiled(true);
+    drawable->tiledArea(sf::Vector2f(width, _tileSize.y));
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::singleDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y * 3, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
+    drawable->SetupSprite(texture);
+    return drawable;
 }
 
 /* getters and setters */

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.cpp
@@ -1,0 +1,220 @@
+#include <Ancona/Core2D/Systems/Drawable/TileBlockDrawable.hpp>
+
+REGISTER_POLYMORPHIC_SERIALIZER(ild::TileBlockDrawable);
+
+using namespace ild;
+
+void TileBlockDrawable::OnDraw(sf::RenderWindow &window, sf::Transform drawableTransform, float delta) {
+    for (auto const & imageDrawable : _imageDrawables) {
+        imageDrawable->Draw(window, drawableTransform, delta);
+    }
+}
+
+void TileBlockDrawable::Serialize(Archive & arc) {
+    Drawable::Serialize(arc);
+    arc(_textureKey, "textureKey");
+    arc(_size, "size");
+}
+
+void TileBlockDrawable::FetchDependencies(const Entity &entity) {
+    Drawable::FetchDependencies(entity);
+    if (_textureKey != "") {
+        auto texture = ResourceLibrary::Get<sf::Texture>(_textureKey);
+        _tileSize = sf::Vector2f(texture->getSize().x / 4, texture->getSize().y / 4);
+        _numTiles = sf::Vector2f(_size.x / _tileSize.x, _size.y / _tileSize.y);
+        SetupImages(texture->copyToImage());
+    }
+}
+
+void TileBlockDrawable::SetupImages(sf::Image image) {
+    if (_numTiles.x > 1 && _numTiles.y > 1) {
+        _imageDrawables.emplace_back(topLeftDrawable(image));
+        _imageDrawables.emplace_back(topRightDrawable(image));
+        _imageDrawables.emplace_back(bottomLeftDrawable(image));
+        _imageDrawables.emplace_back(bottomRightDrawable(image));
+    }
+    if (_numTiles.y > 1) {
+        _imageDrawables.emplace_back(topDrawable(image));
+        _imageDrawables.emplace_back(bottomDrawable(image));
+    }
+    if (_numTiles.x > 1) {
+        _imageDrawables.emplace_back(leftDrawable(image));
+        _imageDrawables.emplace_back(rightDrawable(image));
+    }
+    _imageDrawables.emplace_back(centerDrawable(image));
+}
+
+ImageDrawable * TileBlockDrawable::topLeftDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(0, 0, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_topLeft");
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::topRightDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, 0, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_topRight");
+    drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), 0));
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::bottomLeftDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(0, _tileSize.y * 2, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_bottomLeft");
+    drawable->anchor(sf::Vector2f(0, -(_numTiles.y - 1)));
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::bottomRightDrawable(sf::Image image) {
+    sf::Texture * texture = new sf::Texture();
+    texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, _tileSize.y * 2, _tileSize.x, _tileSize.y));
+    auto drawable = new ImageDrawable(_renderPriority, _key + "_bottomRight");
+    drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), -(_numTiles.y - 1)));
+    drawable->SetupSprite(texture);
+    return drawable;
+}
+
+ImageDrawable * TileBlockDrawable::topDrawable(sf::Image image) {
+    if (_numTiles.x > 1) {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(_tileSize.x, 0, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_top");
+        auto width = _tileSize.x * (_numTiles.x - 2);
+        drawable->anchor(sf::Vector2f(-(_tileSize.x / width), 0));
+        drawable->isTiled(true);
+        drawable->tiledArea(sf::Vector2f(width, _tileSize.y));
+        drawable->SetupSprite(texture);
+        return drawable;
+    } else {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, 0, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_top");
+        drawable->SetupSprite(texture);
+        return drawable;
+    }
+}
+
+ImageDrawable * TileBlockDrawable::bottomDrawable(sf::Image image) {
+    if (_numTiles.x > 1) {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y * 2, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_bottom");
+        auto width = _tileSize.x * (_numTiles.x - 2);
+        drawable->anchor(sf::Vector2f(-(_tileSize.x / width), -(_numTiles.y - 1)));
+        drawable->isTiled(true);
+        drawable->tiledArea(sf::Vector2f(width, _tileSize.y));
+        drawable->SetupSprite(texture);
+        return drawable;
+    } else {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y * 2, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_bottom");
+        drawable->anchor(sf::Vector2f(0, -(_numTiles.y - 1)));
+        drawable->SetupSprite(texture);
+        return drawable;
+    }
+}
+
+ImageDrawable * TileBlockDrawable::leftDrawable(sf::Image image) {
+    if (_numTiles.y > 1) {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(0, _tileSize.y, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_left");
+        auto height = _tileSize.y * (_numTiles.y - 2);
+        drawable->anchor(sf::Vector2f(0, -(_tileSize.y / height)));
+        drawable->isTiled(true);
+        drawable->tiledArea(sf::Vector2f(_tileSize.x, height));
+        drawable->SetupSprite(texture);
+        return drawable;
+    } else {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(0, _tileSize.y * 3, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_left");
+        drawable->SetupSprite(texture);
+        return drawable;
+    }
+}
+
+ImageDrawable * TileBlockDrawable::rightDrawable(sf::Image image) {
+    if (_numTiles.y > 1) {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, _tileSize.y, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_right");
+        auto height = _tileSize.y * (_numTiles.y - 2);
+        drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), -(_tileSize.y / height)));
+        drawable->isTiled(true);
+        drawable->tiledArea(sf::Vector2f(_tileSize.x, height));
+        drawable->SetupSprite(texture);
+        return drawable;
+    } else {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, _tileSize.y * 3, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_right");
+        drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), 0));
+        drawable->SetupSprite(texture);
+        return drawable;
+    }
+}
+
+ImageDrawable * TileBlockDrawable::centerDrawable(sf::Image image) {
+    if (_numTiles.x > 1 && _numTiles.y > 1) {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
+        auto width = _tileSize.x * (_numTiles.x - 2);
+        auto height = _tileSize.y * (_numTiles.y - 2);
+        drawable->anchor(sf::Vector2f(-(_tileSize.x / width), -(_tileSize.y / height)));
+        drawable->isTiled(true);
+        drawable->tiledArea(sf::Vector2f(width, height));
+        drawable->SetupSprite(texture);
+        return drawable;
+    } else if (_numTiles.x == 1 && _numTiles.y > 1) {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
+        auto width = _tileSize.x * (_numTiles.x - 2);
+        auto height = _tileSize.y * (_numTiles.y - 2);
+        drawable->anchor(sf::Vector2f(0, -(_tileSize.y / height)));
+        drawable->isTiled(true);
+        drawable->tiledArea(sf::Vector2f(_tileSize.x, height));
+        drawable->SetupSprite(texture);
+        return drawable;
+    } else if (_numTiles.x > 1 && _numTiles.y == 1) {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y * 3, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
+        auto width = _tileSize.x * (_numTiles.x - 2);
+        auto height = _tileSize.y * (_numTiles.y - 2);
+        drawable->anchor(sf::Vector2f(-(_tileSize.x / width), 0));
+        drawable->isTiled(true);
+        drawable->tiledArea(sf::Vector2f(width, _tileSize.y));
+        drawable->SetupSprite(texture);
+        return drawable;
+    } else {
+        sf::Texture * texture = new sf::Texture();
+        texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y * 3, _tileSize.x, _tileSize.y));
+        auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
+        drawable->SetupSprite(texture);
+        return drawable;
+    }
+}
+
+/* getters and setters */
+int TileBlockDrawable::alpha() {
+    if (_imageDrawables.size() == 0) {
+        return 0;
+    }
+
+    return _imageDrawables[0]->alpha();
+}
+
+void TileBlockDrawable::alpha(int newAlpha) {
+    for (auto const & imageDrawable : _imageDrawables) {
+        imageDrawable->alpha(newAlpha);
+    }
+}

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.hpp
@@ -1,0 +1,48 @@
+#ifndef Ancona_Engine_Core_Systems_TileBlockDrawable_H_
+#define Ancona_Engine_Core_Systems_TileBlockDrawable_H_
+
+#include <memory>
+
+#include <Ancona/Core2D/Systems/Drawable/Drawable.hpp>
+#include <Ancona/Core2D/Systems/Drawable/ImageDrawable.hpp>
+
+namespace ild
+{
+
+class TileBlockDrawable : public Drawable
+{
+    public:
+        TileBlockDrawable() { }
+
+        void Serialize(Archive & arc) override;
+        void FetchDependencies(const Entity & entity) override;
+
+        /* getters and setters */
+        sf::Vector2f size() override { return _size; }
+        void alpha(int newAlpha) override;
+        int alpha() override;
+    private:
+        std::string _textureKey;
+        sf::Vector2f _numTiles;
+        sf::Vector2f _tileSize;
+        sf::Vector2f _size;
+        std::vector<std::unique_ptr<ImageDrawable>> _imageDrawables;
+        std::vector<sf::Texture *> _baseTextures;
+
+        void OnDraw(sf::RenderWindow &window, sf::Transform transform, float delta) override;
+        void SetupImages(sf::Image image);
+
+        ImageDrawable * topLeftDrawable(sf::Image image);
+        ImageDrawable * topRightDrawable(sf::Image image);
+        ImageDrawable * bottomLeftDrawable(sf::Image image);
+        ImageDrawable * bottomRightDrawable(sf::Image image);
+        ImageDrawable * topDrawable(sf::Image image);
+        ImageDrawable * bottomDrawable(sf::Image image);
+        ImageDrawable * leftDrawable(sf::Image image);
+        ImageDrawable * rightDrawable(sf::Image image);
+        ImageDrawable * centerDrawable(sf::Image image);
+};
+
+}
+
+#endif

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.hpp
@@ -41,6 +41,13 @@ class TileBlockDrawable : public Drawable
         ImageDrawable * leftDrawable(sf::Image image);
         ImageDrawable * rightDrawable(sf::Image image);
         ImageDrawable * centerDrawable(sf::Image image);
+        ImageDrawable * topCapDrawable(sf::Image image);
+        ImageDrawable * bottomCapDrawable(sf::Image image);
+        ImageDrawable * leftCapDrawable(sf::Image image);
+        ImageDrawable * rightCapDrawable(sf::Image image);
+        ImageDrawable * verticalCenterDrawable(sf::Image image);
+        ImageDrawable * horizontalCenterDrawable(sf::Image image);
+        ImageDrawable * singleDrawable(sf::Image image);
 };
 
 }

--- a/Engine/Src/Ancona/Core2D/Systems/PathFollowerSystem.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/PathFollowerSystem.cpp
@@ -66,7 +66,7 @@ void PathFollowerComponent::ChangeDirection() {
 
 bool PathFollowerComponent::IsPathDone() {
     return (
-        _nextVertexIndex >= _pathComponent->vertices().size() ||
+        _nextVertexIndex >= (int) _pathComponent->vertices().size() ||
         _nextVertexIndex < 0
     );
 }

--- a/Engine/Src/Ancona/Core2D/Systems/PathSystem.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/PathSystem.cpp
@@ -25,13 +25,13 @@ float PathComponent::TimeForSegment(int segment) {
 }
 
 float PathComponent::DistanceForSegment(int segment) {
-    if (segment == _vertices.size() - 1) {
+    if (segment == (int) _vertices.size() - 1) {
         Assert(_isLoop, "Only loops should care about the last segment length because it connects the end points.")
     }
 
     sf::Vector2f startVertex = _vertices[segment];
     sf::Vector2f endVertex;
-    if (segment == _vertices.size() - 1) {
+    if (segment == (int) _vertices.size() - 1) {
         endVertex = _vertices[0];
     } else {
         endVertex = _vertices[segment + 1];
@@ -42,13 +42,13 @@ float PathComponent::DistanceForSegment(int segment) {
 float PathComponent::TotalDistance() {
     if (_isLoop) {
         float loopDistance = 0;
-        for (int i = 0; i < _vertices.size(); i++) {
+        for (int i = 0; i < (int) _vertices.size(); i++) {
             loopDistance += DistanceForSegment(i);
         }
         return loopDistance;
     } else {
         float backAndForthDistance = 0;
-        for (int i = 0; i < _vertices.size() - 1; i++) {
+        for (int i = 0; i < (int) _vertices.size() - 1; i++) {
             backAndForthDistance += DistanceForSegment(i);
         }
         return backAndForthDistance * 2;

--- a/Test/Unit/AnconaTest/Engine/Core2D/Systems/Drawable/DrawableSystemTests.cpp
+++ b/Test/Unit/AnconaTest/Engine/Core2D/Systems/Drawable/DrawableSystemTests.cpp
@@ -38,7 +38,8 @@ TEST(DrawableSystem, ImageDrawableSize)
 
     sf::Texture texture;
     texture.create(50, 50);
-    ImageDrawable * image = new ImageDrawable(&texture, 0, "image");
+    ImageDrawable * image = new ImageDrawable(0, "image");
+    image->SetupSprite(&texture);
     position.CreateComponent(entity);
     drawable.CreateComponent(entity, image, &position);
 


### PR DESCRIPTION
Resolves #106 
**Commit message:**
Implemented tile block drawables.

`https://github.com/ild-games/Ancona/issues/106`

Tile block drawables allow for drawing out a rectangular image where the border dynamically resolve themselves using a template image.