### PR TITLE
Fix several memory leaks

### DIFF
--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.cpp
@@ -33,7 +33,7 @@ void ContainerDrawable::OnDraw(sf::RenderWindow &window, sf::Transform drawableT
     if (_anchor.x != 0.0f || _anchor.y != 0.0f) {
         auto size = this->size();
         drawableTransform.translate(
-            -(size.x * _anchor.x / std::abs(_scale.x)), 
+            -(size.x * _anchor.x / std::abs(_scale.x)),
             -(size.y * _anchor.y / std::abs(_scale.y)));
     }
     for (auto & drawable : _drawables)
@@ -132,7 +132,7 @@ sf::Vector2f ContainerDrawable::size()
 
 int ContainerDrawable::alpha()
 {
-    if (_drawables[0] != nullptr)
+    if (_drawables.size() != 0u)
     {
         return _drawables[0]->alpha();
     }
@@ -152,16 +152,16 @@ sf::Vector2f ContainerDrawable::position(sf::Vector2f entityPosition)
     float minX = INFINITY, minY = INFINITY;
     for (auto & drawable : _drawables) {
         sf::Vector2f drawablePosition = drawable->position(entityPosition);
-        
+
         if (drawablePosition.x < minX) {
-            minX = drawablePosition.x;     
+            minX = drawablePosition.x;
         }
-        
+
         if (drawablePosition.y < minY) {
-            minY = drawablePosition.y;     
+            minY = drawablePosition.y;
         }
     }
-    
+
     auto size = this->size();
     return sf::Vector2f(minX, minY) - sf::Vector2f(size.x * _anchor.x, size.y * _anchor.y);
 }

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.hpp
@@ -50,6 +50,8 @@ class Drawable
          */
         Drawable () {}
 
+        virtual ~Drawable() {};
+
         /**
          * @brief Constructs a Drawable.
          *
@@ -126,11 +128,11 @@ class Drawable
          * @brief The actual position of a drawable takes in the position from the position component
          *        and also takes into account the anchor of the drawable which might change it's true
          *        position.
-         *  
+         *
          * @param entityPosition The position from the entity's position component
-         * 
+         *
          * @returns The actual position the drawable is drawn at
-         */ 
+         */
         virtual sf::Vector2f position(sf::Vector2f entityPosition);
         virtual sf::Vector2f size() = 0;
         virtual int alpha() = 0;

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableComponent.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableComponent.cpp
@@ -8,11 +8,11 @@ using namespace ild;
 DrawableComponent::DrawableComponent() { }
 
 DrawableComponent::DrawableComponent(
-        Drawable * topDrawable,
+        std::unique_ptr<Drawable> topDrawable,
         DrawableSystem * drawableSystem,
         PositionSystem * positionSystem,
         CameraComponent * cameraComponent) :
-    _topDrawable(topDrawable),
+    _topDrawable(std::move(topDrawable)),
     _camera(cameraComponent),
     _positionSystem(positionSystem),
     _drawableSystem(drawableSystem)

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableComponent.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableComponent.hpp
@@ -26,7 +26,7 @@ class DrawableComponent
          * @brief Default constructor, should only be used by the serializer.
          */
         DrawableComponent();
-    
+
         /**
          * @brief Construct a DrawableComponent.
          *
@@ -34,18 +34,18 @@ class DrawableComponent
          * @param cameraComponent CameraComponent used to render these renderables.
          */
         DrawableComponent(
-                Drawable * topDrawable,
+                std::unique_ptr<Drawable> topDrawable,
                 DrawableSystem * drawableSystem,
                 PositionSystem * positionSystem,
                 CameraComponent * cameraComponent);
-        
+
         DrawableComponent & operator=(DrawableComponent & rhs)
         {
             if (this == &rhs) {
                 return *this;
             }
 
-            _topDrawable = rhs.topDrawable()->Copy();
+            _topDrawable.reset(rhs.topDrawable()->Copy());
             _camera = rhs.cameraComponent();
             _cameraSystem = rhs.cameraSystem();
             _positionSystem = rhs.positionSystem();
@@ -86,7 +86,7 @@ class DrawableComponent
         void Serialize(Archive & arc);
 
         /* getters and setters */
-        Drawable * topDrawable() { return _topDrawable; }
+        Drawable * topDrawable() { return _topDrawable.get(); }
         CameraComponent * cameraComponent() { return _camera; }
         CameraSystem * cameraSystem() { return _cameraSystem; }
         PositionSystem * positionSystem() { return _positionSystem; }
@@ -94,7 +94,7 @@ class DrawableComponent
         DrawableSystem * drawableSystem() { return _drawableSystem; }
         const Entity & camEntity() { return _camEntity; }
     private:
-        Drawable * _topDrawable;
+        std::unique_ptr<Drawable> _topDrawable;
         CameraComponent * _camera;
         CameraSystem * _cameraSystem;
         PositionSystem * _positionSystem;

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableSystem.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableSystem.cpp
@@ -39,20 +39,20 @@ void DrawableSystem::RemoveCamera(CameraComponent * camera)
 
 DrawableComponent * DrawableSystem::CreateComponent(
         const Entity & entity,
-        Drawable * topDrawable,
+        std::unique_ptr<Drawable> topDrawable,
         PositionSystem * position)
 {
     Assert(_defaultCamera != nullptr, "Default camera not set");
-    return CreateComponent(entity, topDrawable, position, _defaultCamera);
+    return CreateComponent(entity, std::move(topDrawable), position, _defaultCamera);
 }
 
 DrawableComponent * DrawableSystem::CreateComponent(
         const Entity & entity,
-        Drawable * topDrawable,
+        std::unique_ptr<Drawable> topDrawable,
         PositionSystem * position,
         CameraComponent * camera)
 {
-    auto comp = new DrawableComponent(topDrawable, this, position, camera);
+    auto comp = new DrawableComponent(std::move(topDrawable), this, position, camera);
 
     if(alg::find(_cameras, camera) == _cameras.end())
     {

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableSystem.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableSystem.hpp
@@ -1,6 +1,7 @@
 #ifndef Ancona_Engine_Core_Systems_DrawableSystem_H_
 #define Ancona_Engine_Core_Systems_DrawableSystem_H_
 
+#include <memory>
 #include <vector>
 
 #include <SFML/Window.hpp>
@@ -66,7 +67,7 @@ class DrawableSystem : public UnorderedSystem<DrawableComponent>
          */
         DrawableComponent * CreateComponent(
                 const Entity & entity,
-                Drawable * topDrawable,
+                std::unique_ptr<Drawable> topDrawable,
                 PositionSystem * position);
 
         /**
@@ -79,7 +80,7 @@ class DrawableSystem : public UnorderedSystem<DrawableComponent>
          */
         DrawableComponent * CreateComponent(
                 const Entity & entity,
-                Drawable * topDrawable,
+                std::unique_ptr<Drawable> topDrawable,
                 PositionSystem * position,
                 CameraComponent * camera);
 

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.cpp
@@ -83,8 +83,14 @@ void TileBlockDrawable::SetupImages(sf::Image image) {
     }
 }
 
+sf::Texture * TileBlockDrawable::createTexture() {
+    auto texture = new sf::Texture();
+    _generatedTextures.emplace_back(texture);
+    return texture;
+}
+
 ImageDrawable * TileBlockDrawable::topLeftDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(0, 0, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_topLeft");
     drawable->SetupSprite(texture);
@@ -92,7 +98,7 @@ ImageDrawable * TileBlockDrawable::topLeftDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::topRightDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, 0, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_topRight");
     drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), 0));
@@ -101,7 +107,7 @@ ImageDrawable * TileBlockDrawable::topRightDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::bottomLeftDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(0, _tileSize.y * 2, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_bottomLeft");
     drawable->anchor(sf::Vector2f(0, -(_numTiles.y - 1)));
@@ -110,7 +116,7 @@ ImageDrawable * TileBlockDrawable::bottomLeftDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::bottomRightDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, _tileSize.y * 2, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_bottomRight");
     drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), -(_numTiles.y - 1)));
@@ -119,7 +125,7 @@ ImageDrawable * TileBlockDrawable::bottomRightDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::topDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x, 0, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_top");
     auto width = _tileSize.x * (_numTiles.x - 2);
@@ -131,7 +137,7 @@ ImageDrawable * TileBlockDrawable::topDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::bottomDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y * 2, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_bottom");
     auto width = _tileSize.x * (_numTiles.x - 2);
@@ -143,7 +149,7 @@ ImageDrawable * TileBlockDrawable::bottomDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::leftDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(0, _tileSize.y, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_left");
     auto height = _tileSize.y * (_numTiles.y - 2);
@@ -155,7 +161,7 @@ ImageDrawable * TileBlockDrawable::leftDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::rightDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, _tileSize.y, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_right");
     auto height = _tileSize.y * (_numTiles.y - 2);
@@ -167,7 +173,7 @@ ImageDrawable * TileBlockDrawable::rightDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::centerDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
     auto width = _tileSize.x * (_numTiles.x - 2);
@@ -180,7 +186,7 @@ ImageDrawable * TileBlockDrawable::centerDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::topCapDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, 0, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_topCap");
     drawable->SetupSprite(texture);
@@ -188,7 +194,7 @@ ImageDrawable * TileBlockDrawable::topCapDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::bottomCapDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y * 2, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_bottomCap");
     drawable->anchor(sf::Vector2f(0, -(_numTiles.y - 1)));
@@ -197,7 +203,7 @@ ImageDrawable * TileBlockDrawable::bottomCapDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::leftCapDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(0, _tileSize.y * 3, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_leftCap");
     drawable->SetupSprite(texture);
@@ -205,7 +211,7 @@ ImageDrawable * TileBlockDrawable::leftCapDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::rightCapDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x * 2, _tileSize.y * 3, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_right");
     drawable->anchor(sf::Vector2f(-(_numTiles.x - 1), 0));
@@ -214,7 +220,7 @@ ImageDrawable * TileBlockDrawable::rightCapDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::verticalCenterDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
     auto width = _tileSize.x * (_numTiles.x - 2);
@@ -227,7 +233,7 @@ ImageDrawable * TileBlockDrawable::verticalCenterDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::horizontalCenterDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x, _tileSize.y * 3, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
     auto width = _tileSize.x * (_numTiles.x - 2);
@@ -240,7 +246,7 @@ ImageDrawable * TileBlockDrawable::horizontalCenterDrawable(sf::Image image) {
 }
 
 ImageDrawable * TileBlockDrawable::singleDrawable(sf::Image image) {
-    sf::Texture * texture = new sf::Texture();
+    auto texture = createTexture();
     texture->loadFromImage(image, sf::IntRect(_tileSize.x * 3, _tileSize.y * 3, _tileSize.x, _tileSize.y));
     auto drawable = new ImageDrawable(_renderPriority, _key + "_center");
     drawable->SetupSprite(texture);

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/TileBlockDrawable.hpp
@@ -32,10 +32,12 @@ class TileBlockDrawable : public Drawable
         sf::Vector2f _size;
         std::vector<std::unique_ptr<ImageDrawable>> _imageDrawables;
         std::vector<sf::Texture *> _baseTextures;
+        std::vector<std::unique_ptr<sf::Texture>> _generatedTextures;
 
         void OnDraw(sf::RenderWindow &window, sf::Transform transform, float delta) override;
         void SetupImages(sf::Image image);
 
+        sf::Texture * createTexture();
         ImageDrawable * topLeftDrawable(sf::Image image);
         ImageDrawable * topRightDrawable(sf::Image image);
         ImageDrawable * bottomLeftDrawable(sf::Image image);

--- a/Engine/Src/Ancona/Framework/Screens/ScreenManager.cpp
+++ b/Engine/Src/Ancona/Framework/Screens/ScreenManager.cpp
@@ -90,7 +90,7 @@ void ScreenManager::RemoveScreen()
     }
     delete _screens.top();
     _screens.pop();
-    
+
     if (_replacementScreen != nullptr) {
         Push(_replacementScreen);
         _replacementScreen = nullptr;
@@ -101,11 +101,11 @@ void ScreenManager::RemoveScreen()
 
 void ScreenManager::SaveScreen()
 {
-    MapSerializer * mapSerializer = new MapSerializer(
+    MapSerializer mapSerializer = MapSerializer(
             _screens.top()->key(),
             *_screens.top()->systemsContainer(),
             false);
-    while(mapSerializer->ContinueLoading())
+    while(mapSerializer.ContinueLoading())
     {
     }
 }

--- a/Engine/Src/Ancona/Framework/Screens/ScreenManager.hpp
+++ b/Engine/Src/Ancona/Framework/Screens/ScreenManager.hpp
@@ -18,7 +18,7 @@ class AbstractScreen;
  *
  * @author Tucker Lein
  */
-class ScreenManager 
+class ScreenManager
 {
     public:
         /**
@@ -69,7 +69,7 @@ class ScreenManager
          * @brief  Checks if the screen manager has any screens
          *         to run.
          *
-         * @return True if there aren't any screens on the 
+         * @return True if there aren't any screens on the
          *         stack, otherwise false.
          */
         bool Empty();

--- a/Test/Unit/AnconaTest/Engine/Core2D/Systems/Drawable/DrawableSystemTests.cpp
+++ b/Test/Unit/AnconaTest/Engine/Core2D/Systems/Drawable/DrawableSystemTests.cpp
@@ -38,10 +38,10 @@ TEST(DrawableSystem, ImageDrawableSize)
 
     sf::Texture texture;
     texture.create(50, 50);
-    ImageDrawable * image = new ImageDrawable(0, "image");
+    std::unique_ptr<ImageDrawable> image {new ImageDrawable(0, "image")};
     image->SetupSprite(&texture);
     position.CreateComponent(entity);
-    drawable.CreateComponent(entity, image, &position);
+    drawable.CreateComponent(entity, std::move(image), &position);
 
     manager.Update(1, UpdateStep::Draw);
 


### PR DESCRIPTION
Ancona was leaking a lot of memory. This commit fixes the following leaks:
* The Drawable class now has a virtual destructor
* The DrawableComponent now stores the top drawable in a unique_ptr
* The TileBlockDrawable cleans up the Textures it creates when it is destroyed
* The ScreenManager was leaking the MapSerializer. Now it is allocated on the stack 