### PR TITLE
Improve Real World Performance

### DIFF
--- a/Engine/Src/Ancona/Core2D/Systems/CameraSystem.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/CameraSystem.cpp
@@ -1,5 +1,7 @@
+#include <Ancona/Util/Assert.hpp>
 #include <Ancona/Core2D/Systems/CameraSystem.hpp>
 #include <Ancona/Core2D/Systems/Drawable/DrawableSystem.hpp>
+
 
 using namespace ild;
 
@@ -33,12 +35,20 @@ void CameraComponent::Update(float delta)
 void CameraComponent::Draw(sf::RenderWindow & window, float delta)
 {
     Box2 cameraPosition(
-        sf::Vector2f(_view.getCenter().x - (_view.getSize().x / 2), _view.getCenter().y - (_view.getSize().y / 2)), 
-        _view.getSize(), 
+        sf::Vector2f(_view.getCenter().x - (_view.getSize().x / 2), _view.getCenter().y - (_view.getSize().y / 2)),
+        _view.getSize(),
         sf::Vector2f(),
         _view.getRotation());
 
     window.setView(_view);
+
+    alg::sort(
+        _renderQueue,
+        [](DrawableComponent * lhs, DrawableComponent * rhs)
+    {
+        return lhs->topDrawable()->renderPriority() < rhs->topDrawable()->renderPriority();
+    });
+
     for(DrawableComponent * drawable : _renderQueue)
     {
         auto drawableBox = drawable->BoundingBox();
@@ -49,7 +59,7 @@ void CameraComponent::Draw(sf::RenderWindow & window, float delta)
     }
 }
 
-sf::Vector2f CameraComponent::GetEffectiveCenter() 
+sf::Vector2f CameraComponent::GetEffectiveCenter()
 {
     sf::Vector2f effectivePosition = _view.getCenter();
     if (_followPosition != nullptr)
@@ -67,16 +77,8 @@ sf::Vector2f CameraComponent::GetEffectiveCenter()
 
 void CameraComponent::AddDrawableComponent(DrawableComponent * drawable)
 {
-    if(!alg::contains(_renderQueue, drawable))
-    {
-        _renderQueue.push_back(drawable);
-        alg::sort(
-                _renderQueue,
-                [](DrawableComponent * lhs, DrawableComponent * rhs)
-                {
-                    return lhs->topDrawable()->renderPriority() < rhs->topDrawable()->renderPriority();
-                });
-    }
+	Assert(!alg::contains(_renderQueue, drawable), "Can't add the same drawable twice.");
+    _renderQueue.push_back(drawable);
 }
 
 void CameraComponent::RemoveDrawableComponent(DrawableComponent * drawable)

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.cpp
@@ -38,7 +38,7 @@ void AnimatedDrawable::OnDraw(sf::RenderWindow &window, sf::Transform drawableTr
     if (_anchor.x != 0.0f || _anchor.y != 0.0f) {
         auto size = this->size();
         drawableTransform.translate(
-            -(size.x * _anchor.x / std::abs(_scale.x)), 
+            -(size.x * _anchor.x / std::abs(_scale.x)),
             -(size.y * _anchor.y / std::abs(_scale.y)));
     }
     _frames[_curFrame]->Draw(window, drawableTransform, delta);
@@ -119,26 +119,26 @@ void AnimatedDrawable::RemoveFrame(const std::string & key)
     }));
 }
 
-void AnimatedDrawable::ResetAnimation() 
+void AnimatedDrawable::ResetAnimation()
 {
     _curFrame = 0;
 }
 
-bool AnimatedDrawable::IsFinished() 
+bool AnimatedDrawable::IsFinished()
 {
     return _curFrame == _frames.size() - 1;
 }
 
 int AnimatedDrawable::NumberOfFrames()
 {
-   return _frames.size(); 
+   return _frames.size();
 }
 
 /* getters and setters */
 sf::Vector2f AnimatedDrawable::size()
 {
     return VectorMath::ComponentMultiplication(
-        _frames[_curFrame]->size(), 
+        _frames[_curFrame]->size(),
         sf::Vector2f(std::abs(_scale.x), std::abs(_scale.y)));
 }
 
@@ -157,19 +157,7 @@ void AnimatedDrawable::alpha(int newAlpha)
 
 sf::Vector2f AnimatedDrawable::position(sf::Vector2f entityPosition)
 {
-    float minX = INFINITY, minY = INFINITY;
-    for (auto & frame : _frames) {
-        sf::Vector2f drawablePosition = frame->position(entityPosition);
-        
-        if (drawablePosition.x < minX) {
-            minX = drawablePosition.x;     
-        }
-        
-        if (drawablePosition.y < minY) {
-            minY = drawablePosition.y;     
-        }
-    }
-    
+    auto position = _frames[_curFrame]->position(entityPosition);
     auto size = this->size();
-    return sf::Vector2f(minX, minY) - sf::Vector2f(size.x * _anchor.x, size.y * _anchor.y);
+    return entityPosition - sf::Vector2f(size.x * _anchor.x, size.y * _anchor.y);
 }

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.hpp
@@ -126,11 +126,11 @@ class Drawable
          * @brief The actual position of a drawable takes in the position from the position component
          *        and also takes into account the anchor of the drawable which might change it's true
          *        position.
-         *  
+         *
          * @param entityPosition The position from the entity's position component
-         * 
+         *
          * @returns The actual position the drawable is drawn at
-         */ 
+         */
         virtual sf::Vector2f position(sf::Vector2f entityPosition);
         virtual sf::Vector2f size() = 0;
         virtual int alpha() = 0;
@@ -170,7 +170,6 @@ class Drawable
          * @brief True if the drawable is actively drawn/updated. Otherwise false.
          */
         bool _inactive = false;
-
     private:
 
         sf::Transform CalculateTransforms();

--- a/Engine/Src/Ancona/Util2D/Collision/Box2.hpp
+++ b/Engine/Src/Ancona/Util2D/Collision/Box2.hpp
@@ -6,6 +6,7 @@
 #include <SFML/System.hpp>
 
 #include <Ancona/Util2D/Collision/Box3.hpp>
+#include <Ancona/Util2D/Collision/Math.hpp>
 
 namespace ild
 {
@@ -106,6 +107,34 @@ class Box2
          * @param vertices A vector used as an output parameter for the vertices.
          */
         void GetVertices(std::vector< std::pair<float,float> > & vertices) const;
+
+        std::pair<float, float> BotRight() const {
+            return Math::RotatePoint(
+                std::pair<float, float>(Position.x + Dimension.x, Position.y + Dimension.y),
+                std::pair<float, float>(Position.x + (Dimension.x * Anchor.x), Position.y + (Dimension.y * Anchor.y)),
+                Rotation);
+        }
+
+        std::pair<float, float> BotLeft() const {
+            return Math::RotatePoint(
+                std::pair<float, float>(Position.x, Position.y + Dimension.y),
+                std::pair<float, float>(Position.x + (Dimension.x * Anchor.x), Position.y + (Dimension.y * Anchor.y)),
+                Rotation);
+        }
+
+        std::pair<float, float> TopLeft() const {
+            return Math::RotatePoint(
+                std::pair<float, float>(Position.x, Position.y),
+                std::pair<float, float>(Position.x + (Dimension.x * Anchor.x), Position.y + (Dimension.y * Anchor.y)),
+                Rotation);
+        }
+
+        std::pair<float, float> TopRight() const {
+            return Math::RotatePoint(
+                std::pair<float, float>(Position.x + Dimension.x, Position.y),
+                std::pair<float, float>(Position.x + (Dimension.x * Anchor.x), Position.y + (Dimension.y * Anchor.y)),
+                Rotation);
+        }
 
         /* getters and setters */
         void position(float x, float y);

--- a/Engine/Src/Ancona/Util2D/Collision/Math.cpp
+++ b/Engine/Src/Ancona/Util2D/Collision/Math.cpp
@@ -39,7 +39,7 @@ Math::Projection2 Math::GetProjection(const Vertices2 & shapeA, const Vector2 & 
         min = fmin(min, dot);
     }
 
-    return Projection2(min,max);
+    return Projection2(min, max);
 }
 
 bool Math::Intersect(const Projection2 & a, const Projection2 & b)
@@ -108,6 +108,10 @@ Math::CollisionFix Math::GetFixVector(const Math::Vertices2 & shapeA, const Math
             min = fix;
             normalOfMin = normal;
         }
+
+        if (min == 0) {
+            break;
+        }
     }
     return Math::CollisionFix {normalOfMin, min};
 }
@@ -120,28 +124,19 @@ bool Math::Collide(const Vertices2 & shapeA, const Vertices2 & shapeB)
 
 bool Math::Collide(const Vertices2 & shapeA, const Vertices2 & shapeB, CollisionFix & collisionFix)
 {
-    if(TestShapeAxis(shapeA,shapeB) &&
-        TestShapeAxis(shapeB,shapeA))
+    CollisionFix fixA = GetFixVector(shapeA, shapeB);
+    CollisionFix fixB = GetFixVector(shapeB, shapeA);
+
+    fixB.magnitude *= -1;
+
+    collisionFix = fabs(fixA.magnitude) <= fabs(fixB.magnitude) ? fixA : fixB;
+
+    if (collisionFix.magnitude < 0)
     {
-        CollisionFix fixA = GetFixVector(shapeA, shapeB);
-        CollisionFix fixB = GetFixVector(shapeB, shapeA);
-
-        fixB.magnitude *= -1;
-
-        collisionFix = fabs(fixA.magnitude) <= fabs(fixB.magnitude) ? fixA : fixB;
-
-        if (collisionFix.magnitude < 0)
-        {
-            collisionFix.magnitude *= -1;
-            collisionFix.normal.first *= -1;
-            collisionFix.normal.second *= -1;
-        }
-
-        return true;
+        collisionFix.magnitude *= -1;
+        collisionFix.normal.first *= -1;
+        collisionFix.normal.second *= -1;
     }
-    else
-    {
-        collisionFix = CollisionFix { Math::Point2(0,0), 0};
-        return false;
-    }
+
+    return collisionFix.magnitude != 0;
 }


### PR DESCRIPTION
Resolves the following performance issues:
* Sorting the drawables when a new drawable is added to the camera caused loading to be log(n) * n ^2. Now we sort drawables before drawing. This guarantees at most one sort per frame.
* Most of the time spent checking collision involves the SAT algorithm. Previously we always used SAT for rotated boxes. Now we sometimes skip SAT if the boxes are far enough apart that they can not overlap.
* A lot of the time spent by the SAT algorithm was allocating the vector used to store the vertices. Now the vectors are static. As a result we allocate the vector at most once. This dramatically sped up SAT because it reduces memory pressure and increases cache locality.
* When we ran SAT we would check for collision then generate the fix vector. The math for these operations is identical. This resulted in us looping over the vertices twice. Now, we execute the loop at most once.