### PR TITLE
Use C++14 instead of C++11.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(BuildTests "BuildTests" ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/BuildTools/Modules)
 
 #Set C++ Version to 11
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -Wall")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -g")
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT ANDROID)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")

--- a/Engine/Src/Ancona/Core2D/Systems/CameraSystem.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/CameraSystem.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <Ancona/Util/Assert.hpp>
 #include <Ancona/Core2D/Systems/CameraSystem.hpp>
 #include <Ancona/Core2D/Systems/Drawable/DrawableSystem.hpp>
@@ -29,7 +31,7 @@ CameraComponent::CameraComponent(
 void CameraComponent::Update(float delta)
 {
     auto effectivePosition = GetEffectiveCenter();
-    _view.setCenter(round(effectivePosition.x), round(effectivePosition.y));
+    _view.setCenter(std::round(effectivePosition.x), std::round(effectivePosition.y));
 }
 
 void CameraComponent::Draw(sf::RenderWindow & window, float delta)

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <Ancona/Core2D/Systems/Drawable/AnimatedDrawable.hpp>
 #include <Ancona/Core2D/Systems/Position/PositionSystem.hpp>
 #include <Ancona/Util2D/VectorMath.hpp>

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <Ancona/Core2D/Systems/Drawable/ContainerDrawable.hpp>
 #include <Ancona/Util2D/VectorMath.hpp>
 

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <Ancona/Core2D/Systems/Drawable/Drawable.hpp>
 #include <Ancona/Core2D/Systems/Drawable/DrawableSystem.hpp>
 

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableComponent.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableComponent.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <Ancona/Core2D/Systems/Drawable/DrawableComponent.hpp>
 #include <Ancona/Core2D/Systems/Drawable/DrawableSystem.hpp>
 #include <Ancona/Core2D/Systems/Position/PositionSystem.hpp>
@@ -29,7 +31,7 @@ Drawable * DrawableComponent::GetDrawable(const std::string & key)
 void DrawableComponent::Draw(sf::RenderWindow &window, float delta)
 {
     sf::Transform transform;
-    transform.translate(round(_positionComponent->position().x), round(_positionComponent->position().y));
+    transform.translate(std::round(_positionComponent->position().x), std::round(_positionComponent->position().y));
     _topDrawable->Draw(window, transform, delta);
 }
 

--- a/Engine/Src/Ancona/Core2D/Systems/Position/PositionSystem.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Position/PositionSystem.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <Ancona/Core2D/Systems/Position/PositionSystem.hpp>
 
 REGISTER_POLYMORPHIC_SERIALIZER(ild::PositionComponent);
@@ -67,8 +69,8 @@ void PositionComponent::Update(float delta)
 
 void PositionComponent::RoundPosition()
 {
-    _position.x = roundf(_actualPosition.x * 128) / 128;
-    _position.y = roundf(_actualPosition.y * 128) / 128;
+    _position.x = std::round(_actualPosition.x * 128) / 128;
+    _position.y = std::round(_actualPosition.y * 128) / 128;
 }
 
 /* getters and setters */


### PR DESCRIPTION
Resolves #116
**Commit message:** 
Update CMakeList to target new c++ version. Fix non standard usage of math
functions.

`https://github.com/ild-games/Ancona/issues/116`