### PR TITLE
Add Virtual Destructor to InputControlComponent

### DIFF
--- a/Engine/Src/Ancona/Core2D/Systems/InputControlComponent.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/InputControlComponent.hpp
@@ -35,6 +35,8 @@ class InputControlComponent
         /* getters and setters */
         InputHandler & handler() { return *_handler; }
         void handler(std::shared_ptr<InputHandler> handler) { _handler = handler; }
+
+        virtual ~InputControlComponent() {};
     private:
         /**
          * @brief Input handler that handles the input gathering


### PR DESCRIPTION
Resolves #118 
**Commit message:**
All polymorphic classes need a virtual destructor. InputControlComponent
did not have a virtual destructor. A new version of asan uncovered this
bug.

`https://github.com/ild-games/Ancona/issues/118`