### PR TITLE
Set asan as a debug flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/BuildTools/Module
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -g")
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT ANDROID)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
 endif()
 
 include_directories(Engine/Src)


### PR DESCRIPTION
Resolves #120 
**Commit message:**
Only enable asan on debug builds.

`https://github.com/ild-games/Ancona/issues/120`

Previously we enabled asan on release builds. Now we only enable it for debug builds. This matches the behavior used by the template game.