### PR TITLE
Drawable enhancements

### DIFF
--- a/Engine/Src/Ancona/Core2D/Systems/CameraSystem.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/CameraSystem.cpp
@@ -58,6 +58,7 @@ void CameraComponent::Draw(sf::RenderWindow & window, float delta)
         {
             drawable->Draw(window, delta);
         }
+        drawable->PostDrawUpdate(delta);
     }
 }
 

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.cpp
@@ -27,8 +27,10 @@ Drawable * AnimatedDrawable::Copy() {
     auto drawable = new AnimatedDrawable();
     Drawable::CopyProperties(drawable);
 
-    drawable->duration(_duration);
-    drawable->loopOnce(_loopOnce);
+    drawable->_duration = _duration;
+    drawable->_loopOnce = _loopOnce;
+    drawable->_timeUntilChange = _timeUntilChange;
+    drawable->_curFrame = _curFrame;
     for (auto & frame : _frames) {
         drawable->AddFrame(frame->Copy());
     }
@@ -68,8 +70,12 @@ void AnimatedDrawable::AdvanceFrame()
         return;
     }
 
-    _curFrame++;
-    if (_curFrame == _frames.size())
+    SetCurrentFrame(_curFrame + 1);
+}
+
+void AnimatedDrawable::SetCurrentFrame(unsigned int frame) {
+    _curFrame = frame;
+    if (_curFrame >= _frames.size())
     {
         ResetAnimation();
     }

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.cpp
@@ -46,9 +46,15 @@ void AnimatedDrawable::OnDraw(sf::RenderWindow &window, sf::Transform drawableTr
             -(size.y * _anchor.y / std::abs(_scale.y)));
     }
     _frames[_curFrame]->Draw(window, drawableTransform, delta);
-    Tick(delta);
 }
 
+void AnimatedDrawable::PostDrawUpdate(float delta) 
+{
+    Tick(delta);
+    for (auto & frame : _frames) {
+        frame->PostDrawUpdate(delta);
+    }
+}
 
 void AnimatedDrawable::Tick(float delta)
 {

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.hpp
@@ -36,6 +36,7 @@ class AnimatedDrawable : public Drawable
                 sf::Vector2f anchor = sf::Vector2f(0.0f, 0.0f));
 
         Drawable * Copy() override;
+        void PostDrawUpdate(float delta) override;
 
         /**
          * @copydoc ild::CameraComponent::Serialize

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/AnimatedDrawable.hpp
@@ -84,6 +84,8 @@ class AnimatedDrawable : public Drawable
          */
         int NumberOfFrames();
 
+        void SetCurrentFrame(unsigned int frame);
+
         /* getters and setters */
         sf::Vector2f size() override;
         sf::Vector2f position(sf::Vector2f entityPosition) override;
@@ -92,11 +94,12 @@ class AnimatedDrawable : public Drawable
         void duration(float duration) { _duration = duration; }
         float duration() { return _duration; }
         void loopOnce(bool loopOnce) { _loopOnce = loopOnce; }
+        unsigned int curFrame() { return _curFrame; }
 
     private:
         std::vector<std::unique_ptr<Drawable>> _frames;
         float _duration;
-        float _timeUntilChange;
+        float _timeUntilChange = 0;
         unsigned int _curFrame = 0;
         bool _loopOnce = false;
 

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.cpp
@@ -75,7 +75,7 @@ void ContainerDrawable::SortDrawables()
 {
     alg::sort(
             _drawables,
-            [](const std::unique_ptr<Drawable> & lhs, const std::unique_ptr<Drawable> & rhs)
+            [](const std::shared_ptr<Drawable> & lhs, const std::shared_ptr<Drawable> & rhs)
             {
                 return lhs->renderPriority() < rhs->renderPriority();
             });
@@ -94,7 +94,7 @@ void ContainerDrawable::AddDrawable(Drawable * drawable)
 
 void ContainerDrawable::RemoveDrawable(const std::string & key)
 {
-    _drawables.erase(alg::remove_if(_drawables, [key](const std::unique_ptr<Drawable> & drawable) {
+    _drawables.erase(alg::remove_if(_drawables, [key](const std::shared_ptr<Drawable> & drawable) {
         return key == drawable->key();
     }));
 }

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.cpp
@@ -44,6 +44,13 @@ void ContainerDrawable::OnDraw(sf::RenderWindow &window, sf::Transform drawableT
     }
 }
 
+void ContainerDrawable::PostDrawUpdate(float delta) 
+{
+    for (auto & childDrawable : _drawables) {
+        childDrawable->PostDrawUpdate(delta);
+    }
+}
+
 void ContainerDrawable::FetchDependencies(const Entity &entity)
 {
     Drawable::FetchDependencies(entity);

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.hpp
@@ -36,6 +36,7 @@ class ContainerDrawable : public Drawable
                 sf::Vector2f anchor = sf::Vector2f(0.0f, 0.0f));
 
         Drawable * Copy() override;
+        void PostDrawUpdate(float delta) override;
 
         /**
          * @copydoc ild::CameraComponent::Serialize

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.hpp
@@ -62,7 +62,7 @@ class ContainerDrawable : public Drawable
          */
         void RemoveDrawable(const std::string & key);
 
-        /**j
+        /**
          * @copydoc ild::Drawable::FindDrawable
          */
         Drawable * FindDrawable(const std::string & key) override;

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/ContainerDrawable.hpp
@@ -61,10 +61,19 @@ class ContainerDrawable : public Drawable
          */
         void RemoveDrawable(const std::string & key);
 
-        /**
+        /**j
          * @copydoc ild::Drawable::FindDrawable
          */
         Drawable * FindDrawable(const std::string & key) override;
+
+        typedef std::vector<std::shared_ptr<Drawable>>::iterator iterator;
+
+        iterator begin() {
+            return _drawables.begin();
+        }
+        iterator end() {
+            return _drawables.end();
+        }
 
         /* getters and setters */
         sf::Vector2f size() override;
@@ -72,8 +81,11 @@ class ContainerDrawable : public Drawable
         int alpha() override;
         void alpha(int alpha) override;
 
+
     private:
-        std::vector<std::unique_ptr<Drawable>> _drawables;
+        
+
+        std::vector<std::shared_ptr<Drawable>> _drawables;
 
         void SortDrawables();
         void OnDraw(sf::RenderWindow &window, sf::Transform drawableTransform, float delta) override;

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/Drawable.hpp
@@ -77,6 +77,8 @@ class Drawable
                 sf::Transform parentTransform,
                 float delta);
 
+        virtual void PostDrawUpdate(float delta) { }
+
         virtual Drawable * Copy() = 0;
         void CopyProperties(Drawable * drawable);
 

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableComponent.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableComponent.cpp
@@ -35,6 +35,12 @@ void DrawableComponent::Draw(sf::RenderWindow &window, float delta)
     _topDrawable->Draw(window, transform, delta);
 }
 
+
+void DrawableComponent::PostDrawUpdate(float delta)
+{
+    _topDrawable->PostDrawUpdate(delta);
+}
+
 Box2 DrawableComponent::BoundingBox()
 {
     return Box2(

--- a/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableComponent.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Drawable/DrawableComponent.hpp
@@ -68,6 +68,7 @@ class DrawableComponent
          * @param window RenderWindow to draw it on
          */
         void Draw(sf::RenderWindow & window, float delta);
+        void PostDrawUpdate(float delta);
 
         /**
          * @copydoc ild::CameraComponent::FetchDependencies


### PR DESCRIPTION
Resolves #122 
**Commit message:**

- Allows the update of which frame an animation is on to be kept up to date when off screen

- Allows setting a specific frame on an animation drawable

- Adds iterator to container drawable to loop through its child drawables

`https://github.com/ild-games/Ancona/issues/122`

Rendering of drawables is turned off when off screen, however the animation's don't update which frame they are on unless they are rendered. This should be separated from rendering.