### PR TITLE
prefix the ild namespace in the ILD_Log statement

### DIFF
--- a/Engine/Src/Ancona/System/Log.hpp
+++ b/Engine/Src/Ancona/System/Log.hpp
@@ -25,7 +25,7 @@ class LogControls
 }
 
 #define ILD_Log(message) {\
-    LogControls::_log(message);\
+    ild::LogControls::_log(message);\
 }
 
 #endif


### PR DESCRIPTION
Resolves #126 
**Commit message:**
Add the ild namespace to the LogControls class call in the ILD_Log macro. 

`https://github.com/ild-games/Ancona/issues/126`

Without this, it caused a compile error when invoking the macro outside of the ild namespace