### PR TITLE
Patch SFML Deadlock

### DIFF
--- a/Engine/Src/Ancona/Core2D/Core/Game.cpp
+++ b/Engine/Src/Ancona/Core2D/Core/Game.cpp
@@ -1,5 +1,6 @@
 #include <Ancona/Core2D/Core/Game.hpp>
 #include <Ancona/Framework/Screens/ScreenManager.hpp>
+#include <Ancona/Framework/Resource/ResourceLibrary.hpp>
 #include <Ancona/Core2D/InputDevices/Keyboard.hpp>
 #include <Ancona/Core2D/InputDevices/Mouse.hpp>
 #include <Ancona/Core2D/InputDevices/Touch.hpp>
@@ -13,6 +14,10 @@ Game::Game(
     _window(sf::VideoMode(windowWidth, windowHeight), title)
 {
     _screenManager = new ScreenManager(_window, windowWidth, windowHeight);
+}
+
+Game::~Game() {
+    ResourceLibrary::GarbageCollect();
 }
 
 void Game::Run()

--- a/Engine/Src/Ancona/Core2D/Core/Game.hpp
+++ b/Engine/Src/Ancona/Core2D/Core/Game.hpp
@@ -26,6 +26,8 @@ class Game
          */
         void Run();
 
+        virtual ~Game();
+
     protected:
         /**
          * @brief Instance of the game manager

--- a/Engine/Src/Ancona/Framework/Resource/ResourceLibrary.hpp
+++ b/Engine/Src/Ancona/Framework/Resource/ResourceLibrary.hpp
@@ -96,6 +96,12 @@ class ResourceLibrary
          * @return Path to the resource root.
          */
         static std::string ResourceRoot();
+
+        /**
+         * @brief Looks through the resources and deletes any that have a
+         *        reference counter of 0.
+         */
+        static void GarbageCollect();
         
 
     private:
@@ -116,11 +122,6 @@ class ResourceLibrary
 
         static std::unordered_map<std::string, std::unordered_map<std::string, std::string>> _alternateSources;
 
-        /**
-         * @brief Looks through the resources and deletes any that have a
-         *        reference counter of 0.
-         */
-        static void GarbageCollect();
         static void DeleteResource(const std::string & type, const std::string & key);
         static const std::string & FileToLoad(const std::string & type, const std::string & key);
 };

--- a/Engine/Src/Ancona/Framework/Serializing/MapSerializer.cpp
+++ b/Engine/Src/Ancona/Framework/Serializing/MapSerializer.cpp
@@ -154,15 +154,5 @@ void MapSerializer::SerializeSpecifiedSystem(
 
 void MapSerializer::SaveMapFiles()
 {
-    if (_loading)
-    {
-        return;
-    }
-
-    auto saveStream = FileOperations::GetOutputFileStream(Config::GetOption("SaveData"));
-    _saveRoot["profiles"][_profile] = _saveProfileRoot;
-    (*saveStream) << _saveRoot;
-
-    auto mapStream = FileOperations::GetOutputFileStream("maps/" + _mapName + ".map");
-    (*mapStream) << _mapRoot;
+    // TODO Implement Snapshot Save
 }

--- a/Engine/Src/Ancona/System/Android/FileOperations.cpp
+++ b/Engine/Src/Ancona/System/Android/FileOperations.cpp
@@ -82,12 +82,6 @@ std::istream * AndroidFileOperations::GetAndroidFileInputStream(const std::strin
     {
         auto apkFileStream = OpenFile(desiredFile);
         Assert(apkFileStream != nullptr, "Could not find the " + desiredFile + " file in app storage or within apk.");
-
-        std::string output;
-        output = apkFileStream->str();
-
-
-        WriteApkFileToNonApkStorage(desiredFile, new std::istringstream(apkFileStream->str()));
         return new std::istringstream(apkFileStream->str());
     }
 }
@@ -128,12 +122,6 @@ bool AndroidFileOperations::FilesDirPresent()
 void AndroidFileOperations::MakeFilesDir()
 {
     FileOperations::CreateDirectory(_internalPath);
-}
-
-void AndroidFileOperations::WriteApkFileToNonApkStorage(const std::string & filename, std::istream * streamToWrite)
-{
-    auto outFile = FileOperations::GetOutputFileStream(filename);
-    (*outFile) << streamToWrite->rdbuf();
 }
 
 std::string FileOperations::ResourceRoot() 

--- a/Raft/Patches/sfml-fix-android-shutdown.patch
+++ b/Raft/Patches/sfml-fix-android-shutdown.patch
@@ -1,0 +1,51 @@
+diff --git a/src/SFML/Main/MainAndroid.cpp b/src/SFML/Main/MainAndroid.cpp
+index 595a3a2..7b4f57b 100644
+--- a/src/SFML/Main/MainAndroid.cpp
++++ b/src/SFML/Main/MainAndroid.cpp
+@@ -337,7 +337,7 @@ static void onNativeWindowCreated(ANativeActivity* activity, ANativeWindow* wind
+ 
+     // Wait for the event to be taken into account by SFML
+     states->updated = false;
+-    while(!states->updated)
++    while(!(states->updated | states->terminated))
+     {
+         states->mutex.unlock();
+         sf::sleep(sf::milliseconds(10));
+@@ -362,7 +362,7 @@ static void onNativeWindowDestroyed(ANativeActivity* activity, ANativeWindow* wi
+ 
+     // Wait for the event to be taken into account by SFML
+     states->updated = false;
+-    while(!states->updated)
++    while(!(states->updated | states->terminated))
+     {
+         states->mutex.unlock();
+         sf::sleep(sf::milliseconds(10));
+@@ -393,6 +393,7 @@ static void onInputQueueCreated(ANativeActivity* activity, AInputQueue* queue)
+     {
+         sf::Lock lock(states->mutex);
+ 
++        ALooper_acquire(states->looper);
+         AInputQueue_attachLooper(queue, states->looper, 1, states->processEvent, NULL);
+         states->inputQueue = queue;
+     }
+@@ -409,8 +410,10 @@ static void onInputQueueDestroyed(ANativeActivity* activity, AInputQueue* queue)
+     {
+         sf::Lock lock(states->mutex);
+ 
+-        states->inputQueue = NULL;
+         AInputQueue_detachLooper(queue);
++        states->inputQueue = NULL;
++
++        ALooper_release(states->looper);
+     }
+ }
+ 
+@@ -541,7 +544,7 @@ void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, size_
+     // Wait for the main thread to be initialized
+     states->mutex.lock();
+ 
+-    while (!states->initialized)
++    while (!(states->initialized | states->terminated))
+     {
+         states->mutex.unlock();
+         sf::sleep(sf::milliseconds(20));

--- a/Raft/raftfile.json
+++ b/Raft/raftfile.json
@@ -22,12 +22,13 @@
             },
             "buildSystem" : "cmake",
             "patches" : [
-                "Patches/sfml-fix-android-build.patch",
                 "Patches/gcc5-fix.patch",
+                "Patches/sfml-fix-android-build.patch",
+                "Patches/sfml-fix-android-shutdown.patch",
                 "Patches/sfml-fix-ios-clipboard-compile-error.patch",
+                "Patches/sfml-fix-macos-linker-errors.patch",
                 "Patches/sfml-ios-use-toolchain.patch",
-                "Patches/sfml-monkey-patch-ios-openal.patch",
-                "Patches/sfml-fix-macos-linker-errors.patch"
+                "Patches/sfml-monkey-patch-ios-openal.patch"
             ]
         }
     ],


### PR DESCRIPTION
There is a deadlock in SFML cleanup code. This patches the issue. A fix
will be contributed upstream to SFML. Once the fix is released, we
should bump the SFML version used by Ancona. The Game destructor now
collects old resources. This fixes a bug where the old resources crashed
the game when Android reuses the process.