### PR TITLE
Projection Based Collision

### DIFF
--- a/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.hpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionComponent.hpp
@@ -72,15 +72,19 @@ class CollisionComponent
          * @param fixNormal Output variable used to return the normal used
          *  to fix the collision.
          * @param fixMagnitude Magnitude of the vector used to push the objects apart.
+         * @param delta Delta used for calculating the projection.
          *
          * @return True if the components collide.  False otherwise.
          */
-        bool Collides(const CollisionComponent & otherComponent, Point & fixNormal, float & fixMagnitude) const;
+        bool Collides(const CollisionComponent & otherComponent,
+                      Point & fixNormal,
+                      float & fixMagnitude) const;
 
         /**
-         * @brief Update the internal state for purpose of collision.
+         * @brief Update the snapshot used for calculating diffs. Snapshot should be taken after all
+         *        collision fixes are applied.
          */
-        void Update();
+        void UpdateSnapshot();
 
         /**
          * @copydoc ild::CameraComponent::FetchDependencies
@@ -121,6 +125,8 @@ class CollisionComponent
         bool enabled() const { return _enabled; } 
         void enabled(const bool & newEnabled) { _enabled = newEnabled; } 
 
+        sf::Vector2f movement() const { return _dim.Position - _positionSnapshot; }
+
     private:
         PositionComponent * _position;
         CollisionSystem * _system;
@@ -129,6 +135,11 @@ class CollisionComponent
         BodyTypeEnum _bodyType;
         sf::Vector2f _anchor;
         bool _enabled = true;
+
+        /* 
+        * Not serialized
+        */ 
+        sf::Vector2f _positionSnapshot;
 };
 
 }

--- a/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionSystem.cpp
+++ b/Engine/Src/Ancona/Core2D/Systems/Collision/CollisionSystem.cpp
@@ -66,7 +66,6 @@ void CollisionSystem::FixCollision(CollisionComponent * a, CollisionComponent * 
     {
         PushApart(a, b, correctFix);
     }
-
 }
 
 void CollisionSystem::PushFirstOutOfSecond(CollisionComponent *a, CollisionComponent *b, const Point &correctFix)
@@ -101,7 +100,7 @@ void CollisionSystem::Update(float delta)
     //Update all of the entities.  This is required for the position to be up to date.
     for(EntityComponentPair pair : * this)
     {
-        pair.second->Update();
+        pair.second->UpdateDimensionPosition();
     }
 
     for (EntityComponentPair entityComponentPairA : * this)
@@ -118,10 +117,11 @@ void CollisionSystem::Update(float delta)
                 continue;
             }
 
-
             Point fixNormal;
             float fixMagnitude;
-            if (entityComponentPairA.second->Collides(*entityComponentPairB.second, fixNormal, fixMagnitude))
+            if (entityComponentPairA.second->Collides(*entityComponentPairB.second,
+                                                      fixNormal,
+                                                      fixMagnitude))
             {
                 HandleCollision(
                     entityComponentPairA,
@@ -132,6 +132,11 @@ void CollisionSystem::Update(float delta)
             entityComponentPairA.second->UpdateDimensionPosition();
             entityComponentPairB.second->UpdateDimensionPosition();
         }
+    }
+
+    for(EntityComponentPair pair : * this)
+    {
+        pair.second->UpdateSnapshot();
     }
 }
 


### PR DESCRIPTION
Squatbot has been suffering from the bullet through the wall problem. This implements primitive projection based collision. Since it doesn't handle rotation, and we need Box2 to handle rotation when determining what we should draw, the new collision implementation was not pushed into the Box2 class.